### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/VirtualTeacherGenAIDemo.Server/Services/DashboardService.cs
+++ b/VirtualTeacherGenAIDemo.Server/Services/DashboardService.cs
@@ -112,6 +112,12 @@ namespace VirtualTeacherGenAIDemo.Server.Services
 
         public async Task<string> GetPrompt(string functionName, string plugin)
         {
+            if (functionName.Contains("..") || functionName.Contains("/") || functionName.Contains("\\") ||
+                plugin.Contains("..") || plugin.Contains("/") || plugin.Contains("\\"))
+            {
+                throw new ArgumentException("Invalid functionName or plugin");
+            }
+
             string? promptStream = await ReadFunction.Read(Path.Combine(_pluginsDirectory, plugin, functionName),
                 FunctionFileType.Prompt);
             return promptStream!;


### PR DESCRIPTION
Fixes [https://github.com/fwickert/VirtualTeacherGenAIDemo/security/code-scanning/1](https://github.com/fwickert/VirtualTeacherGenAIDemo/security/code-scanning/1)

To fix the problem, we need to validate the user-provided `functionName` and `plugin` parameters before using them to construct the file path. We should ensure that these parameters do not contain any path separators or parent directory references. This can be done by checking for the presence of "..", "/", and "\\" characters in the input and rejecting the input if any are found.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
