### PR TITLE
Add refreshUI parameter and UI refresh button

### DIFF
--- a/VirtualTeacherGenAIDemo.Server/Controllers/DashboardController.cs
+++ b/VirtualTeacherGenAIDemo.Server/Controllers/DashboardController.cs
@@ -20,64 +20,60 @@ namespace VirtualTeacherGenAIDemo.Server.Controllers
         [HttpPost("summary", Name = "summary")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IResult> Post([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest,
-            string sessionId, string userName, CancellationToken token)
+            string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
             //Check if conversation, chatId, connectionId, and id are not null
             if (string.IsNullOrEmpty(dashboardRequest.Conversation) || string.IsNullOrEmpty(dashboardRequest.SessionId) ||
-                string.IsNullOrEmpty(dashboardRequest.ConnectionId) )
+                string.IsNullOrEmpty(dashboardRequest.ConnectionId))
             {
                 return TypedResults.BadRequest("Invalid request : Invalid Body");
             }
 
-            return await dashboardService.GetSummarize(dashboardRequest, sessionId, userName, token);
+            return await dashboardService.GetSummarize(dashboardRequest, sessionId, userName, refreshUI, token);
         }
 
         [HttpPost("products", Name = "products")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async  Task<IResult> PostProducts([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest,
-            string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> PostProducts([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest,
+            string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
-            return await dashboardService.GetProducts(dashboardRequest, sessionId, userName, token);
+            return await dashboardService.GetProducts(dashboardRequest, sessionId, userName, refreshUI, token);
         }
 
         //same for keywords
         [HttpPost("keywords", Name = "keywords")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async  Task<IResult> PostKeywords([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest, 
-            string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> PostKeywords([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest,
+            string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
-            return await dashboardService.GetKeywords(dashboardRequest, sessionId, userName, token);
+            return await dashboardService.GetKeywords(dashboardRequest, sessionId, userName, refreshUI, token);
         }
 
         //same for advice
         [HttpPost("advice", Name = "advice")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<IResult> PostAdvice([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest, 
-            string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> PostAdvice([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest,
+            string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
-            return await dashboardService.GetAdvice(dashboardRequest, sessionId, userName, token);
+            return await dashboardService.GetAdvice(dashboardRequest, sessionId, userName, refreshUI, token);
         }
 
         //same for Example
         [HttpPost("example", Name = "example")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<IResult> PostExample([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest, 
-            string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> PostExample([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest,
+            string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
-            return await dashboardService.GetExample(dashboardRequest, sessionId, userName, token);
+            return await dashboardService.GetExample(dashboardRequest, sessionId, userName, refreshUI, token);
         }
 
         //same for evaluation
         [HttpPost("evaluation", Name = "evaluation")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async  Task<IResult> PostEvaluation([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest, 
-            string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> PostEvaluation([FromServices] DashboardService dashboardService, [FromBody] DashboardRequest dashboardRequest,
+            string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
-            return await dashboardService.GetEvaluation(dashboardRequest, sessionId, userName, token);
+            return await dashboardService.GetEvaluation(dashboardRequest, sessionId, userName, refreshUI, token);
         }
-
-
     }
-
-
 }

--- a/VirtualTeacherGenAIDemo.Server/Controllers/SessionController.cs
+++ b/VirtualTeacherGenAIDemo.Server/Controllers/SessionController.cs
@@ -85,10 +85,10 @@ namespace VirtualTeacherGenAIDemo.Server.Controllers
             forKeywords.Conversation = conversation.ToString();
             forAdvice.Conversation = conversation.ToString();
 
-            await _dashboardService.GetSummarize(forSummary, request.SessionId, request.UserId, token);
-            await _dashboardService.GetProducts(forProducts, request.SessionId, request.UserId, token);
-            await _dashboardService.GetKeywords(forKeywords, request.SessionId, request.UserId, token);
-            await _dashboardService.GetAdvice(forAdvice, request.SessionId, request.UserId, token);            
+            await _dashboardService.GetSummarize(forSummary, request.SessionId, request.UserId,false, token);
+            await _dashboardService.GetProducts(forProducts, request.SessionId, request.UserId,false, token);
+            await _dashboardService.GetKeywords(forKeywords, request.SessionId, request.UserId,false, token);
+            await _dashboardService.GetAdvice(forAdvice, request.SessionId, request.UserId,false, token);            
 
         }
 

--- a/VirtualTeacherGenAIDemo.Server/Services/DashboardService.cs
+++ b/VirtualTeacherGenAIDemo.Server/Services/DashboardService.cs
@@ -27,7 +27,7 @@ namespace VirtualTeacherGenAIDemo.Server.Services
             _searchService = searchService;
         }
 
-        public async Task<IResult> GetSummarize(DashboardRequest dashboardRequest, string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> GetSummarize(DashboardRequest dashboardRequest, string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
             _dashboardResponse.FunctionName = "Summary";
 
@@ -37,15 +37,15 @@ namespace VirtualTeacherGenAIDemo.Server.Services
             _ = Task.Run(() => _dashboardResponse.GetAsync(dashboardRequest.SessionId, dashboardRequest.Id, "Summary",
                                new Dictionary<string, string>()
                                {
-                    { "conversation", dashboardRequest.Conversation },                    
+                    { "conversation", dashboardRequest.Conversation },
                     { "task", summaryPrompt }
-            }, dashboardRequest.ConnectionId, token), token);
+            }, dashboardRequest.ConnectionId, refreshUI, token), token);
 
             return TypedResults.Ok("Summarize requested");
         }
 
         //return products
-        public async Task<IResult> GetProducts(DashboardRequest dashboardRequest, string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> GetProducts(DashboardRequest dashboardRequest, string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
             _dashboardResponse.FunctionName = "Products";
 
@@ -55,16 +55,16 @@ namespace VirtualTeacherGenAIDemo.Server.Services
             _ = Task.Run(() => _dashboardResponse.GetAsync(dashboardRequest.SessionId, dashboardRequest.Id, "Products",
                 new Dictionary<string, string>()
                 {
-                    { "conversation", dashboardRequest.Conversation },                    
+                    { "conversation", dashboardRequest.Conversation },
                     { "task", productPrompt }
                 }
-                , dashboardRequest.ConnectionId, token), token);
+                , dashboardRequest.ConnectionId, refreshUI, token), token);
 
             return TypedResults.Ok("Products requested");
         }
 
         //Get Keywords
-        public async Task<IResult> GetKeywords(DashboardRequest dashboardRequest, string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> GetKeywords(DashboardRequest dashboardRequest, string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
             _dashboardResponse.FunctionName = "Keywords";
 
@@ -74,15 +74,15 @@ namespace VirtualTeacherGenAIDemo.Server.Services
             _ = Task.Run(() => _dashboardResponse.GetAsync(dashboardRequest.SessionId, dashboardRequest.Id, "Keywords",
                 new Dictionary<string, string>()
                 {
-                    { "conversation", dashboardRequest.Conversation },                    
+                    { "conversation", dashboardRequest.Conversation },
                     { "task", keywordPrompt }
-                }, dashboardRequest.ConnectionId, token), token);
+                }, dashboardRequest.ConnectionId, refreshUI, token), token);
 
             return TypedResults.Ok("Keywords requested");
         }
 
         //get advice
-        public async Task<IResult> GetAdvice(DashboardRequest dashboardRequest, string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> GetAdvice(DashboardRequest dashboardRequest, string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
             _dashboardResponse.FunctionName = "Advice";
 
@@ -102,15 +102,13 @@ namespace VirtualTeacherGenAIDemo.Server.Services
                     {"knowledge", search },
                     { "task", advicePrompt },
                     { "roleplay", agentRolePlay.Name }
-                }, dashboardRequest.ConnectionId, token), token);
+                }, dashboardRequest.ConnectionId, refreshUI, token), token);
 
             return TypedResults.Ok("Advice requested");
         }
 
-     
-
         //for Example
-        public async Task<IResult> GetExample(DashboardRequest dashboardRequest, string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> GetExample(DashboardRequest dashboardRequest, string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
             _dashboardResponse.FunctionName = "Example";
 
@@ -121,13 +119,13 @@ namespace VirtualTeacherGenAIDemo.Server.Services
                 {
                     { "conversation", dashboardRequest.Conversation },
                     { "userPrompt", agentTeacher.Prompt }
-                }, dashboardRequest.ConnectionId, token), token);
+                }, dashboardRequest.ConnectionId, refreshUI, token), token);
 
             return TypedResults.Ok("Example requested");
         }
 
         //for evaluation
-        public async Task<IResult> GetEvaluation(DashboardRequest dashboardRequest, string sessionId, string userName, CancellationToken token)
+        public async Task<IResult> GetEvaluation(DashboardRequest dashboardRequest, string sessionId, string userName, bool refreshUI, CancellationToken token)
         {
             _dashboardResponse.FunctionName = "Evaluation";
 
@@ -142,7 +140,7 @@ namespace VirtualTeacherGenAIDemo.Server.Services
                     { "conversation", dashboardRequest.Conversation },
                     { "userPrompt", agentTeacher.Prompt },
                     { "knowledge", search }
-                }, dashboardRequest.ConnectionId, token), token);
+                }, dashboardRequest.ConnectionId, refreshUI, token), token);
 
             return TypedResults.Ok("Evaluation requested");
         }

--- a/VirtualTeacherGenAIDemo.Server/Services/LLMResponse.cs
+++ b/VirtualTeacherGenAIDemo.Server/Services/LLMResponse.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Elastic.Clients.Elasticsearch;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.SemanticKernel;
 using VirtualTeacherGenAIDemo.Server.Hubs;
@@ -31,7 +32,8 @@ namespace VirtualTeacherGenAIDemo.Server.Services
             _pluginsDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Plugins");
         }
 
-        public async Task GetAsync(string sessionId, string id, string whatAbout, Dictionary<string, string> variablesContext, string connectionId, CancellationToken token)
+        public async Task GetAsync(string sessionId, string id, string whatAbout, Dictionary<string, string> variablesContext, 
+            string connectionId, bool refreshUI, CancellationToken token)
         {
             var arguments = new KernelArguments();
 
@@ -40,8 +42,15 @@ namespace VirtualTeacherGenAIDemo.Server.Services
                 arguments[item.Key] = item.Value;
             }
 
-            //await StreamResponseToClient(sessionId, id, whatAbout, arguments, connectionId, token);
-            await NoStreamingResponseToClient(sessionId, id, whatAbout, arguments, connectionId, token);
+
+            if (refreshUI)
+            {
+                await StreamResponseToClient(sessionId, id, whatAbout, arguments, connectionId, token);
+            }
+            else
+            {
+                await NoStreamingResponseToClient(sessionId, id, whatAbout, arguments, connectionId, token);
+            }
         }
 
         public async Task GetCoachAsync(string whatAbout, Dictionary<string, string> variablesContext, string connectionId, CancellationToken token)
@@ -108,7 +117,7 @@ namespace VirtualTeacherGenAIDemo.Server.Services
                 InfoType = whatAbout
             });
             
-            //await this.UpdateMessageOnClient( messageResponse, connectionId, token);
+            await this.UpdateMessageOnClient(whatAbout, messageResponse, connectionId, token);
             
         }
 

--- a/virtualteachergenaidemo.client/src/components/dashboard/DashboardFeatureResult.tsx
+++ b/virtualteachergenaidemo.client/src/components/dashboard/DashboardFeatureResult.tsx
@@ -3,22 +3,38 @@ import { useState, useEffect } from 'react';
 import { Skeleton2Rows } from '../../components/Utilities/skeleton2rows';
 import MarkdownRenderer from '../Utilities/markdownRenderer';
 import { HubConnection } from '@microsoft/signalr';
-//import { Button } from '@fluentui/react-button';
-//import { DialogPrompt } from '../Utilities/DialogPrompt';
+import { Button } from '@fluentui/react-button';
+import { ArrowSyncFilled } from '@fluentui/react-icons';
 import DashboardService from '../../services/DashboardService';
 import { useLocalization } from '../../contexts/LocalizationContext';
+import { DashboardRequest } from '../../models/Request/DashboardRequest';
+import { makeStyles } from '@fluentui/react-components';
 
-interface DashboardFeatureResultProps {    
+interface DashboardFeatureResultProps {
     data: any;
     infoType: string;
     loading: boolean;
-    connection: HubConnection | null;    
+    connection: HubConnection | null;
+    sessionId: string;
+    userName: string;
+    conversation: string;
 }
-
-const DashboardFeatureResult: React.FC<DashboardFeatureResultProps> = ({ data, infoType, loading, connection}) => {
+const useStyles = makeStyles({
+    button: {
+        border: 'none',        
+        position: 'absolute',
+        top: '8px',
+        right: '8px'        
+    },
+    container: {
+        position: 'relative'
+    }
+});
+const DashboardFeatureResult: React.FC<DashboardFeatureResultProps> = ({ data, infoType, loading, connection, sessionId, userName, conversation }) => {
     const [content, setContent] = useState(data?.content || '');
     const [isLoading, setIsLoading] = useState(loading);
     const { getTranslation } = useLocalization();
+    const styles = useStyles();
 
     useEffect(() => {
         if (connection) {
@@ -45,12 +61,31 @@ const DashboardFeatureResult: React.FC<DashboardFeatureResultProps> = ({ data, i
         });
     };
 
+    const handleRefreshClick = async () => {
+        setIsLoading(true);
+        try {
+            const body: DashboardRequest = {
+                sessionId: sessionId,
+                id: infoType,
+                conversation: conversation,
+                connectionId: connection?.connectionId || '',
+                title: '' // Add the actual title if needed
+            };
+            const updatedData = await DashboardService.postFeature(infoType, sessionId, userName, body, true);
+            setContent(updatedData.content);            
+        } catch (error) {
+            console.error('Error refreshing data:', error);
+            setIsLoading(false);
+        }
+    };
+
     return (
         <div role="tabpanel" aria-labelledby={infoType} className="tabpanel">
-            {/*<Button onClick={() => callApiForFeature(infoType, data)}>{getTranslation("GenerateButton")} {infoType}</Button>*/}
-            {/*<DialogPrompt title={infoType} />*/}
-            <section className="frame">
+            <section className={`frame ${styles.container}`}>
                 <span id={infoType}>
+                    <Button
+                        icon={<ArrowSyncFilled style={{ fontSize: '16px' }} />} 
+                        onClick={handleRefreshClick} className={styles.button} />
                     {isLoading ? <Skeleton2Rows /> :
                         content ? <MarkdownRenderer markdown={content} /> : <span>{getTranslation("NoGenerateYet")}</span>
                     }
@@ -61,4 +96,3 @@ const DashboardFeatureResult: React.FC<DashboardFeatureResultProps> = ({ data, i
 };
 
 export { DashboardFeatureResult };
-

--- a/virtualteachergenaidemo.client/src/components/dashboard/dashboardTabs.tsx
+++ b/virtualteachergenaidemo.client/src/components/dashboard/dashboardTabs.tsx
@@ -64,6 +64,9 @@ const DashboardTabs: React.FC<DashboardTabsProps> = ({ sessionId, conversation, 
                     loading={loading}
                     infoType={infoType}
                     connection={connection}
+                    sessionId={sessionId}
+                    userName={userName}
+                    conversation={conversation}
                 ></DashboardFeatureResult>
             </div>
         )

--- a/virtualteachergenaidemo.client/src/models/Request/DashboardRequest.ts
+++ b/virtualteachergenaidemo.client/src/models/Request/DashboardRequest.ts
@@ -1,0 +1,7 @@
+export interface DashboardRequest {
+    sessionId: string;
+    id: string;
+    conversation: string;
+    connectionId: string;
+    title: string;
+}

--- a/virtualteachergenaidemo.client/src/services/DashboardService.ts
+++ b/virtualteachergenaidemo.client/src/services/DashboardService.ts
@@ -7,11 +7,12 @@ class DashboardService {
         return response.data;
     }
 
-    async postFeature(feature: string, sessionId: string, userName: string, body: any): Promise<any> {
+    async postFeature(feature: string, sessionId: string, userName: string, body: any, refreshUI: boolean): Promise<any> {
         const response = await axios.post(`/api/dashboard/${feature}`, body, {
             params: {
                 sessionId: sessionId,
-                userName: userName
+                userName: userName,
+                refreshUI: refreshUI
             }
         });
         return response.data;


### PR DESCRIPTION
Introduce a new `refreshUI` parameter to methods in `DashboardController`, `SessionController`, and `DashboardService` to control UI refresh behavior. Update `LLMResponse.GetAsync` to conditionally call response methods based on `refreshUI`. Add a refresh button to `DashboardFeatureResult.tsx` for manual UI refresh, using Fluent UI's `Button` and `ArrowSyncFilled` icon. Update `DashboardTabs.tsx` to pass additional props to `DashboardFeatureResult`. Add `DashboardRequest` interface for dashboard API calls. Minor changes in `LLMResponse.cs` include a new import and handling of `refreshUI` in `GetAsync`.